### PR TITLE
github action using node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ outputs:
     description: 'HTML string'
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'lib/main.js'
 
 branding:


### PR DESCRIPTION
Just bumped `node16` to `node20` due to deprecation warnings